### PR TITLE
fix the parse_hamiltonian_string

### DIFF
--- a/Hamiltonian_to_Pennylane.py
+++ b/Hamiltonian_to_Pennylane.py
@@ -3,10 +3,10 @@ def parse_hamiltonian_string(hamiltonian_str):
     """
     Parse the input Hamiltonian string into a list of tuples.
     """
-    term_pattern = re.compile(r'([\+\-]?\d+\.\d+)\s*\*\s*([IXYZ]+)')
+    term_pattern = re.compile(r'([\+\-]?\s{0,}\d+\.\d+)\s*\*\s*([IXYZ]+)')
     terms = term_pattern.findall(hamiltonian_str)
-   
-    parsed_terms = [(term[1], float(term[0])) for term in terms]
+    
+    parsed_terms = [(term[1], float(term[0].replace(" ", ""))) for term in terms]
     return parsed_terms
 
 def convert_to_pennylane_format(term_str, coefficient):


### PR DESCRIPTION
When running Python code, the actual value is positive and negative, but the output value is always positive.

We found that `parse_hamiltonian_string` function is incorrect because in reference text, there are space between [+/-] and float value. 

In `re.compile` function,  We add the space.
and before converting float, remove the space

``` python
def parse_hamiltonian_string(hamiltonian_str):
    """
    Parse the input Hamiltonian string into a list of tuples.
    """
    term_pattern = re.compile(r'([\+\-]?\s{0,}\d+\.\d+)\s*\*\s*([IXYZ]+)')
    terms = term_pattern.findall(hamiltonian_str)
    
    parsed_terms = [(term[1], float(term[0].replace(" ", ""))) for term in terms]
    return parsed_terms

```

Original output
```
(-51.1139071673799) [I0]
+ (12.41620827390893) [Z11]
+ (0.12057948842535543) [Y10 Y11]
+ (0.12057948842535543) [X10 X11]
+ (0.0327578387990602) [Y9 Z10 Y11]
+ (0.0327578387990602) [X9 Z10 X11]
+ (0.04610075485943312) [Y6 Z7 Z8 Z9 Z10 Y11]
+ (0.04610075485943312) [X6 Z7 Z8 Z9 Z10 X11]
+ (1.6634978319040625) [Z10]
```
Fixed output
```
(-51.1139071673799) [I0]
+ (12.41620827390893) [Z11]
+ (0.12057948842535543) [Y10 Y11]
+ (0.12057948842535543) [X10 X11]
+ (0.0327578387990602) [Y9 Z10 Y11]
+ (0.0327578387990602) [X9 Z10 X11]
+ (-0.04610075485943312) [Y6 Z7 Z8 Z9 Z10 Y11]
+ (-0.04610075485943312) [X6 Z7 Z8 Z9 Z10 X11]
+ (1.6634978319040625) [Z10]
```